### PR TITLE
Add Clinical Lycanthropy

### DIFF
--- a/Walking corpse syndrome
+++ b/Walking corpse syndrome
@@ -5,3 +5,5 @@ blood drained or their organs removed. Yet other patients show delusions of immo
 The condition is most common among schizophrenics and people who’ve suffered head trauma. In one famous case,a young man who hit his head 
 in a motorcycle accident in Scotland left the hospital convinced he was dead from either septicemia or AIDS. Shortly afterward, when his 
 mother took him to South Africa, he came to believe that his soul had been sent to hell.
+
+Reference- http://all-that-is-interesting.com

--- a/Walking corpse syndrome
+++ b/Walking corpse syndrome
@@ -1,4 +1,4 @@
-The "Walkiing Corpse Syndrome"
+The "Walkiing Corpse Syndrome" or Cotard's Delusion
 
 People with Cotard’s syndrome believe that they have either died or been mutilated in some improbable manner such as having all of their
 blood drained or their organs removed. Yet other patients show delusions of immortality..

--- a/Walking corpse syndrome
+++ b/Walking corpse syndrome
@@ -1,4 +1,5 @@
 The "Walkiing Corpse Syndrome" or Cotard's Delusion
+Person thinks or believes that he/she are or have been dead.
 
 People with Cotard’s syndrome believe that they have either died or been mutilated in some improbable manner such as having all of their
 blood drained or their organs removed. Yet other patients show delusions of immortality..

--- a/Walking corpse syndrome
+++ b/Walking corpse syndrome
@@ -1,0 +1,7 @@
+The "Walkiing Corpse Syndrome"
+
+People with Cotard’s syndrome believe that they have either died or been mutilated in some improbable manner such as having all of their
+blood drained or their organs removed. Yet other patients show delusions of immortality..
+The condition is most common among schizophrenics and people who’ve suffered head trauma. In one famous case,a young man who hit his head 
+in a motorcycle accident in Scotland left the hospital convinced he was dead from either septicemia or AIDS. Shortly afterward, when his 
+mother took him to South Africa, he came to believe that his soul had been sent to hell.


### PR DESCRIPTION
Clinical Lycanthropy
The effected person starts to believe that he/she has trnsformed into an animal.
Clinical Lycanthropy is a mental illness (specifically, a psychiatric syndrome) that involves a strong delusional belief in the afflicted person that they have transformed into an animal, often a wolf. The syndrome is diagnosed by either a lucid patient indicating that he or she has at one time transformed into an animal, or by observing certain animal behaviors in the patient that would indicate a belief that he or she is currently transformed into some animal. The belief is caused by a form of psychosis or dementia, and causes the person to whole-heartedly believe that they have become a certain animal.

![](http://l.yimg.com/fz/api/res/1.2/EcjTRzs9TL8LylVR5g8f_A--~C/YXBwaWQ9c3JjaGRkO2g9NjUzO3E9ODA7dz02MDA-/https://flyingtigercomics.files.wordpress.com/2014/06/4e4eb-clinical-lycanthropy.jpg)
